### PR TITLE
8.1 optional fix

### DIFF
--- a/SwiftData.swift
+++ b/SwiftData.swift
@@ -1580,7 +1580,9 @@ public struct SwiftData {
                     return nil
                 }
                 let imageAsData = NSData(contentsOfFile: fullPath)
-                return UIImage(data: imageAsData)
+                if let imageAsData = imageAsData {
+                    return UIImage(data: imageAsData)
+                }
             }
             return nil
         }


### PR DESCRIPTION
As of 8.1: NSData returns an optional, but UIImage data needs it to be required
